### PR TITLE
[refactor] Apply consistent arrow function syntax to components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import KanbanBoardPage from "@pages/KanbanBoardPage";
 import GanttChartPage from "@pages/GanttChartPage";
 import MembersPage from "@pages/MembersPage";
 
-function App() {
+const App = () => {
   return (
     <Router>
       <Routes>
@@ -27,6 +27,6 @@ function App() {
       </Routes>
     </Router>
   );
-}
+};
 
 export default App;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet, useParams } from "react-router-dom";
 import LeftToolPane from "@components/LeftToolPane";
 import { useProjectStore } from "@store/useProjectStore";
 
-function Layout() {
+const Layout = () => {
   const { id } = useParams<{ id: string }>();
   const projects = useProjectStore((state) => state.projects);
   const project = id ? projects.find((p) => p.id === Number(id)) : null;
@@ -15,6 +15,6 @@ function Layout() {
       </div>
     </div>
   );
-}
+};
 
 export default Layout;

--- a/src/components/LeftToolPane.tsx
+++ b/src/components/LeftToolPane.tsx
@@ -21,7 +21,7 @@ interface LeftToolPaneProps {
   project: Project;
 }
 
-function LeftToolPane({ project }: LeftToolPaneProps) {
+const LeftToolPane = ({ project }: LeftToolPaneProps) => {
   const navigate = useNavigate();
   const [selectedTool, setSelectedTool] = useState<number | null>(2);
 
@@ -82,6 +82,6 @@ function LeftToolPane({ project }: LeftToolPaneProps) {
       </div>
     </div>
   );
-}
+};
 
 export default LeftToolPane;

--- a/src/components/common/CustomDataPicker.tsx
+++ b/src/components/common/CustomDataPicker.tsx
@@ -9,7 +9,7 @@ interface CustomDatePickerProps {
   onChange: (date: Date | null) => void;
 }
 
-function CustomDatePicker({ value, onChange }: CustomDatePickerProps) {
+const CustomDatePicker = ({ value, onChange }: CustomDatePickerProps) => {
   return (
     <div className="w-full">
       <DatePicker
@@ -26,7 +26,7 @@ function CustomDatePicker({ value, onChange }: CustomDatePickerProps) {
       />
     </div>
   );
-}
+};
 
 const CustomInput = forwardRef((props: any, ref) => {
   return (

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -6,7 +6,7 @@ interface IconProps {
   alt?: string;
 }
 
-function Icon({ name, className, alt }: IconProps) {
+const Icon = ({ name, className, alt }: IconProps) => {
   const IconComponent = useMemo(
     () =>
       React.lazy(() =>
@@ -23,6 +23,6 @@ function Icon({ name, className, alt }: IconProps) {
       <IconComponent className={className} aria-label={alt} />
     </Suspense>
   );
-}
+};
 
 export default Icon;

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -9,14 +9,14 @@ interface ModalProps {
   onClick: () => void;
 }
 
-function Modal({
+const Modal = ({
   title,
   isOpen,
   onClose,
   buttonLabel,
   onClick,
   children,
-}: PropsWithChildren<ModalProps>) {
+}: PropsWithChildren<ModalProps>) => {
   return isOpen ? (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center">
       <div className="flex flex-col bg-white p-6 rounded-lg min-w-fit">
@@ -36,6 +36,6 @@ function Modal({
       </div>
     </div>
   ) : null;
-}
+};
 
 export default Modal;

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -4,11 +4,7 @@ interface TextFieldProps {
   errorMessage?: string;
 }
 
-const TextField: React.FC<TextFieldProps> = ({
-  value,
-  onChange,
-  errorMessage,
-}) => {
+const TextField = ({ value, onChange, errorMessage }: TextFieldProps) => {
   return (
     <div className="h-[65px]">
       <input

--- a/src/components/projectList/CircularProgress.tsx
+++ b/src/components/projectList/CircularProgress.tsx
@@ -5,12 +5,12 @@ interface CircularProgressProps {
   className?: string;
 }
 
-const CircularProgress: React.FC<CircularProgressProps> = ({
+const CircularProgress = ({
   progress,
   className,
   size = 100,
   strokeWidth = 10,
-}) => {
+}: CircularProgressProps) => {
   // 원의 반지름
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;

--- a/src/components/projectList/CreateProjectForm.tsx
+++ b/src/components/projectList/CreateProjectForm.tsx
@@ -17,11 +17,11 @@ interface CreateProjectFormProps {
   setErrorMsg: React.Dispatch<React.SetStateAction<ErrorMessage>>;
 }
 
-function CreateProjectForm({
+const CreateProjectForm = ({
   setFormData,
   errorMessages,
   setErrorMsg,
-}: CreateProjectFormProps) {
+}: CreateProjectFormProps) => {
   const [name, setName] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [endDate, setEndDate] = useState<Date | null>(null);
@@ -78,6 +78,6 @@ function CreateProjectForm({
       </label>
     </form>
   );
-}
+};
 
 export default CreateProjectForm;

--- a/src/components/projectList/ProjectList.tsx
+++ b/src/components/projectList/ProjectList.tsx
@@ -7,7 +7,7 @@ import MonthlyProjectBox from "@components/projectList/MonthlyProjectBox";
 /**
  * 프로젝트 리스트 컴포넌트입니다.
  */
-function ProjectList() {
+const ProjectList = () => {
   const projects = useProjectStore((state) => state.projects); // 최신순으로 sort되어 넘어온다고 가정
   const [groupedProjects, setGroupedProjects] = useState<
     Map<number, Map<number, Project[]>>
@@ -43,6 +43,6 @@ function ProjectList() {
       ))}
     </div>
   );
-}
+};
 
 export default ProjectList;

--- a/src/components/sections/Header.tsx
+++ b/src/components/sections/Header.tsx
@@ -4,7 +4,7 @@ interface HeaderProps {
   onClick?: () => void;
 }
 
-function Header({ title, buttonLabel, onClick }: HeaderProps) {
+const Header = ({ title, buttonLabel, onClick }: HeaderProps) => {
   return (
     <div className="flex justify-between items-center">
       <h1 className="text-2xl font-bold">{title}</h1>
@@ -20,6 +20,6 @@ function Header({ title, buttonLabel, onClick }: HeaderProps) {
       )}
     </div>
   );
-}
+};
 
 export default Header;

--- a/src/pages/GanttChartPage.tsx
+++ b/src/pages/GanttChartPage.tsx
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useProjectStore } from "@store/useProjectStore";
 
-function GanttChartPage() {
+const GanttChartPage = () => {
   const { id } = useParams<{ id: string }>();
   const projects = useProjectStore((state) => state.projects);
   const project = projects.find((p) => p.id === Number(id));
@@ -13,6 +13,6 @@ function GanttChartPage() {
   return (
     <div className="ml-[300px] p-10">{`<${project.name}> 간트 차트 페이지`}</div>
   );
-}
+};
 
 export default GanttChartPage;

--- a/src/pages/KanbanBoardPage.tsx
+++ b/src/pages/KanbanBoardPage.tsx
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useProjectStore } from "@store/useProjectStore";
 
-function KanbanBoardPage() {
+const KanbanBoardPage = () => {
   const { id } = useParams<{ id: string }>();
   const projects = useProjectStore((state) => state.projects);
   const project = projects.find((p) => p.id === Number(id));
@@ -13,6 +13,6 @@ function KanbanBoardPage() {
   return (
     <div className="ml-[300px] p-10">{`<${project.name}> 칸반 보드 페이지`}</div>
   );
-}
+};
 
 export default KanbanBoardPage;

--- a/src/pages/MembersPage.tsx
+++ b/src/pages/MembersPage.tsx
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useProjectStore } from "@store/useProjectStore";
 
-function MembersPage() {
+const MembersPage = () => {
   const { id } = useParams<{ id: string }>();
   const projects = useProjectStore((state) => state.projects);
   const project = projects.find((p) => p.id === Number(id));
@@ -13,6 +13,6 @@ function MembersPage() {
   return (
     <div className="ml-[300px] p-10">{`<${project.name}> 구성원 관리 페이지`}</div>
   );
-}
+};
 
 export default MembersPage;

--- a/src/pages/ProjectListPage.tsx
+++ b/src/pages/ProjectListPage.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import Project from "@models/Project";
 import { format } from "date-fns";
 
-function ProjectListPage() {
+const ProjectListPage = () => {
   const navigate = useNavigate();
   const [formData, setFormData] = useState<FormData>({});
   const [errorMsg, setErrorMsg] = useState<ErrorMessage>({});
@@ -87,6 +87,6 @@ function ProjectListPage() {
       </Modal>
     </div>
   );
-}
+};
 
 export default ProjectListPage;

--- a/src/pages/ProjectMainPage.tsx
+++ b/src/pages/ProjectMainPage.tsx
@@ -1,8 +1,8 @@
 /**
  * 프로젝트 메인 화면입니다.
  */
-function ProjectMainPage() {
+const ProjectMainPage = () => {
   return <div>Project Main 화면</div>;
-}
+};
 
 export default ProjectMainPage;


### PR DESCRIPTION
- Standardize component definitions using arrow function syntax
- Replace React.FC<> with explicit prop type annotations
  - e.g., const Component = (`{ prop1, prop2 }: ComponentProps`) => { ... }