### PR TITLE
[feat] update task at gantt chart

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useParams } from "react-router-dom";
 import LeftToolPane from "@components/LeftToolPane";
 import { useProjectData } from "@/hooks/project/useProjectMutation";
 import LoadingComponent from "@components/common/LoadingComponent";
@@ -8,9 +8,20 @@ import {
 } from "@/context/TaskSelectContext";
 import RightToolPane from "./RightToolPane";
 import Project from "@/models/Project";
+import { useProjectStore } from "@/store/useProjectStore";
+import { useEffect } from "react";
 
 const Layout = () => {
-  const { data: project, isLoading } = useProjectData();
+  const { id } = useParams<{ id: string }>();
+  const { projectId, setProjectId } = useProjectStore();
+
+  useEffect(() => {
+    if (id && id !== projectId) {
+      setProjectId(id);
+    }
+  }, [id, projectId, setProjectId]);
+
+  const { data: project, isLoading } = useProjectData(id ?? "");
 
   if (isLoading) {
     return <LoadingComponent />;

--- a/src/components/RightToolPane.tsx
+++ b/src/components/RightToolPane.tsx
@@ -17,6 +17,7 @@ import { useProjectData } from "@/hooks/project/useProjectMutation";
 import { useTaskMutations } from "@/hooks/task/useTaskMutation";
 import KebabMenu from "./common/KebabMenu";
 import Modal from "./common/Modal";
+import { useProjectStore } from "@/store/useProjectStore";
 
 const RightToolPane = ({ isSubTask = false }: RightToolPaneProps) => {
   const {
@@ -25,7 +26,8 @@ const RightToolPane = ({ isSubTask = false }: RightToolPaneProps) => {
     selectedSubTaskId,
     setSelectedSubTaskId,
   } = useTaskSelectContext();
-  const { data: project } = useProjectData();
+  const { projectId } = useProjectStore();
+  const { data: project } = useProjectData(projectId);
   if (project === null) {
     return null;
   }

--- a/src/components/ganttChart/gantt.config.ts
+++ b/src/components/ganttChart/gantt.config.ts
@@ -44,7 +44,7 @@ export const configureGantt = () => {
           <span>${task.status}</span>
         </div>
       `,
-      width: 150,
+      width: 120,
     },
   ];
 
@@ -60,4 +60,6 @@ export const configureGantt = () => {
     { unit: "year", step: 1, date: "%Y년" },
   ];
   gantt.config.links = false; // 링크를 비활성화
+  gantt.config.drag_progress = false; // 진행 상태 수정 비활성화
+  gantt.config.drag_move = false; // 작업 이동 비활성화
 };

--- a/src/components/kanbanBoard/TaskForm.tsx
+++ b/src/components/kanbanBoard/TaskForm.tsx
@@ -22,11 +22,12 @@ export interface ErrorMessage {
   date?: string;
 }
 
-interface CreateTaskFormProps {
+interface TaskFormProps {
+  formData: FormData;
   setFormData: React.Dispatch<React.SetStateAction<FormData>>;
-  errorMessages: ErrorMessage;
-  setErrorMsg: React.Dispatch<React.SetStateAction<ErrorMessage>>;
   members: Member[];
+  errorMsg: ErrorMessage;
+  clearFieldError: (value: string) => void;
 }
 
 interface SearchableItem {
@@ -35,19 +36,27 @@ interface SearchableItem {
   subLabel?: string;
 }
 
-const CreateTaskForm = ({
+const TaskForm = ({
+  formData,
   setFormData,
-  errorMessages,
-  setErrorMsg,
   members,
-}: CreateTaskFormProps) => {
-  const [name, setName] = useState<string>("");
-  const [description, setDescription] = useState<string>("");
-  const [status, setStatus] = useState<Status>("ToDo");
-  const [startDate, setStartDate] = useState<Date | null>(null);
-  const [endDate, setEndDate] = useState<Date | null>(null);
+  errorMsg,
+  clearFieldError,
+}: TaskFormProps) => {
+  const [name, setName] = useState<string>(formData.name);
+  const [description, setDescription] = useState<string>(formData.description);
+  const [status, setStatus] = useState<Status>(formData.status);
+  const [startDate, setStartDate] = useState<Date | null>(
+    formData.startDate === "" ? null : new Date(formData.startDate)
+  );
+  const [endDate, setEndDate] = useState<Date | null>(
+    formData.endDate === "" ? null : new Date(formData.endDate)
+  );
   const [searchValue, setSearchValue] = useState("");
-  const [selectedMembers, setSelectedMembers] = useState<Member[]>([]);
+  const [selectedMembers, setSelectedMembers] = useState<Member[]>(
+    formData.managers
+  );
+
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
 
   const statusOptions: Option[] = [
@@ -94,7 +103,7 @@ const CreateTaskForm = ({
   };
 
   const handleChangeName = (value: string) => {
-    setErrorMsg((prev) => ({ ...prev, name: "" }));
+    clearFieldError("name");
     setName(value);
     setFormData((prev) => ({ ...prev, name: value }));
   };
@@ -111,7 +120,7 @@ const CreateTaskForm = ({
 
   const handleChangeStartDate = (date: Date | null) => {
     setStartDate(date);
-    setErrorMsg((prev) => ({ ...prev, date: "" }));
+    clearFieldError("date");
     if (date) {
       setFormData((prev) => ({
         ...prev,
@@ -145,7 +154,7 @@ const CreateTaskForm = ({
   };
 
   return (
-    <form className="flex flex-col w-[800px] p-8">
+    <form className="flex flex-col w-[800px] pt-6 pr-5 pb-0 pl-5">
       <div className="grid grid-cols-[2fr,1fr] gap-8">
         {/* 왼쪽 영역 */}
         <div className="space-y-8 border-r border-gray-200 pr-8">
@@ -156,7 +165,7 @@ const CreateTaskForm = ({
             <TextField
               value={name}
               onChange={handleChangeName}
-              errorMessage={errorMessages["name"]}
+              errorMessage={errorMsg["name"]}
               placeholder="제목을 입력하세요"
             />
           </div>
@@ -167,7 +176,7 @@ const CreateTaskForm = ({
               value={description}
               onChange={handleChangeDescription}
               placeholder="설명을 입력하세요"
-              className="min-h-[200px] w-full overflow-y-auto"
+              className="min-h-[100px] w-full overflow-y-auto"
             />
           </div>
 
@@ -181,7 +190,7 @@ const CreateTaskForm = ({
                 endDate={endDate}
                 onChangeStart={handleChangeStartDate}
                 onChangeEnd={handleChangeEndDate}
-                errorMessage={errorMessages["date"]}
+                errorMessage={errorMsg["date"]}
                 isOpen={isDatePickerOpen}
                 onOpenChange={setIsDatePickerOpen}
               />
@@ -254,4 +263,4 @@ const CreateTaskForm = ({
   );
 };
 
-export default CreateTaskForm;
+export default TaskForm;

--- a/src/hooks/project/useProjectMutation.ts
+++ b/src/hooks/project/useProjectMutation.ts
@@ -1,13 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { useParams } from "react-router-dom";
 import { fetchProjectById } from "@api/projectApi";
 
-export const useProjectData = () => {
-  const { id } = useParams<{ id: string }>();
+export const useProjectData = (projectId: string) => {
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["project", id],
-    queryFn: () => fetchProjectById(id!),
-    enabled: !!id, // id가 없을 경우 쿼리 실행 차단
+    queryKey: ["project", projectId],
+    queryFn: () => fetchProjectById(projectId!),
+    enabled: !!projectId, // id가 없을 경우 쿼리 실행 차단
   });
 
   return {

--- a/src/hooks/task/useTaskMutation.ts
+++ b/src/hooks/task/useTaskMutation.ts
@@ -11,9 +11,13 @@ import Project from "@/models/Project";
 
 interface UseTaskMutationProps {
   projectId: string;
+  onSuccess?: () => void;
 }
 
-export const useTaskMutations = ({ projectId }: UseTaskMutationProps) => {
+export const useTaskMutations = ({
+  projectId,
+  onSuccess,
+}: UseTaskMutationProps) => {
   const queryClient = useQueryClient();
 
   const updateTaskMutation = useMutation<
@@ -62,6 +66,7 @@ export const useTaskMutations = ({ projectId }: UseTaskMutationProps) => {
       queryClient.invalidateQueries({
         queryKey: ["project", projectId],
       });
+      onSuccess?.();
     },
     onError: (err, variables, context) => {
       if (context?.previousProject) {

--- a/src/hooks/task/useTaskValidation.ts
+++ b/src/hooks/task/useTaskValidation.ts
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { ErrorMessage, FormData } from "@/components/kanbanBoard/TaskForm";
+
+export const useTaskValidation = () => {
+  const [errorMsg, setErrorMsg] = useState<ErrorMessage>({});
+
+  const validationCheck = (formData: FormData) => {
+    const { name, startDate, endDate } = formData;
+
+    let hasError = false;
+    if (!name || name.trim() === "") {
+      setErrorMsg((prev) => ({
+        ...prev,
+        ["name"]: "제목을 입력해주세요",
+      }));
+      hasError = true;
+    }
+
+    let dateErrorMsg = "";
+    if (!startDate || startDate.trim() === "") {
+      dateErrorMsg += "시작일";
+    }
+    if (!endDate || endDate.trim() === "") {
+      if (dateErrorMsg !== "") {
+        dateErrorMsg += "/마감일을 선택해주세요";
+      } else {
+        dateErrorMsg += "마감일을 선택해주세요";
+      }
+    }
+    if (dateErrorMsg !== "") {
+      setErrorMsg((prev) => ({
+        ...prev,
+        ["date"]: dateErrorMsg,
+      }));
+      hasError = true;
+    }
+
+    if (hasError) return false;
+
+    return true;
+  };
+
+  const resetErrors = () => setErrorMsg({});
+
+  // 특정 필드의 에러 메시지 초기화
+  const clearFieldError = (field: string) => {
+    setErrorMsg((prev) =>
+      Object.fromEntries(Object.entries(prev).filter(([key]) => key !== field))
+    );
+  };
+
+  return { errorMsg, resetErrors, clearFieldError, validationCheck };
+};

--- a/src/pages/GanttChartPage.tsx
+++ b/src/pages/GanttChartPage.tsx
@@ -1,9 +1,11 @@
 import { useProjectData } from "@/hooks/project/useProjectMutation";
 import GanttChart from "@/components/ganttChart/GanttChart";
 import Header from "@components/Header";
+import { useProjectStore } from "@/store/useProjectStore";
 
 const GanttChartPage = () => {
-  const { data: project } = useProjectData();
+  const { projectId } = useProjectStore();
+  const { data: project } = useProjectData(projectId);
 
   return (
     <div className="flex flex-col ml-[250px] p-5 px-12 border-box h-full">

--- a/src/pages/MembersPage.tsx
+++ b/src/pages/MembersPage.tsx
@@ -1,7 +1,9 @@
 import { useProjectData } from "@/hooks/project/useProjectMutation";
+import { useProjectStore } from "@/store/useProjectStore";
 
 const MembersPage = () => {
-  const { data: project } = useProjectData();
+  const { projectId } = useProjectStore();
+  const { data: project } = useProjectData(projectId);
 
   return (
     <div className="ml-[300px] p-10">{`<${project!.name}> 구성원 관리 페이지`}</div>

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -1,114 +1,12 @@
 import { create } from "zustand";
-import Project from "@models/Project";
-import Task from "@models/Task";
-import Member from "@models/Member";
 
 interface ProjectStore {
-  projects: Project[];
-  // 기본 CRUD 작업
-  setProjects: (projects: Project[]) => void;
-  addProject: (project: Project) => void;
-  updateProject: (id: string, project: Partial<Project>) => void;
-  deleteProject: (id: string) => void;
-  getProject: (id: string) => Project | undefined;
-
-  // 프로젝트 관련 작업
-  updateProgress: (id: string, progress: number) => void;
-  addMember: (projectId: string, member: Member) => void;
-  removeMember: (projectId: string, memberId: string) => void;
-
-  // 작업(Task) 관련
-  addTask: (projectId: string, task: Task) => void;
-  updateTask: (projectId: string, taskId: string, task: Partial<Task>) => void;
-  deleteTask: (projectId: string, taskId: string) => void;
+  projectId: string;
+  setProjectId: (id: string) => void;
 }
 
-export const useProjectStore = create<ProjectStore>((set, get) => ({
-  projects: [],
-
-  setProjects: (projects) => set({ projects }),
-
-  addProject: (project) =>
-    set((state) => ({
-      projects: [...state.projects, project],
-    })),
-
-  updateProject: (id, updatedProject) =>
-    set((state) => ({
-      projects: state.projects.map((project) =>
-        project.id === id ? { ...project, ...updatedProject } : project
-      ),
-    })),
-
-  deleteProject: (id) =>
-    set((state) => ({
-      projects: state.projects.filter((project) => project.id !== id),
-    })),
-
-  getProject: (id) => get().projects.find((project) => project.id === id),
-
-  updateProgress: (id, progress) =>
-    set((state) => ({
-      projects: state.projects.map((project) =>
-        project.id === id ? { ...project, progress } : project
-      ),
-    })),
-
-  addMember: (projectId, member) =>
-    set((state) => ({
-      projects: state.projects.map((project) =>
-        project.id === projectId
-          ? { ...project, members: [...project.members, member] }
-          : project
-      ),
-    })),
-
-  removeMember: (projectId, memberId) =>
-    set((state) => ({
-      projects: state.projects.map((project) =>
-        project.id === projectId
-          ? {
-              ...project,
-              members: project.members.filter(
-                (member) => member.id !== memberId
-              ),
-            }
-          : project
-      ),
-    })),
-
-  addTask: (projectId, task) =>
-    set((state) => ({
-      projects: state.projects.map((project) =>
-        project.id === projectId
-          ? { ...project, tasks: [...project.tasks, task] }
-          : project
-      ),
-    })),
-
-  updateTask: (projectId, taskId, updatedTask) =>
-    set((state) => ({
-      projects: state.projects.map((project) =>
-        project.id === projectId
-          ? {
-              ...project,
-              tasks: project.tasks.map((task) =>
-                task.id === taskId ? { ...task, ...updatedTask } : task
-              ),
-            }
-          : project
-      ),
-    })),
-
-  deleteTask: (projectId, taskId) =>
-    set((state) => ({
-      projects: state.projects.map((project) =>
-        project.id === projectId
-          ? {
-              ...project,
-              tasks: project.tasks.filter((task) => task.id !== taskId),
-            }
-          : project
-      ),
-    })),
+export const useProjectStore = create<ProjectStore>((set) => ({
+  projectId: "",
+  setProjectId: (id) => set({ projectId: id }),
+  clearProjectId: () => set({ projectId: "" }),
 }));

--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -1,0 +1,21 @@
+import Task from "@models/Task";
+
+export interface GanttChartTask extends Task {
+  parent?: string;
+}
+
+export const flattenTasksForGanttChart = (tasks: Task[]) => {
+  const processTask = (task: Task) => {
+    const flattenSubTasks = task.subTasks.map((subTask) => {
+      return {
+        ...subTask,
+        parent: task.id,
+      };
+    });
+    return [task, ...flattenSubTasks];
+  };
+
+  const flatTasks: GanttChartTask[] = [];
+  tasks.forEach((task) => flatTasks.push(...processTask(task)));
+  return flatTasks;
+};


### PR DESCRIPTION
- Added color indicators for status in Gantt chart
- Implemented subTask display in Gantt chart
- Refactored CreateTaskForm to be reusable for editing tasks
- Extracted task validation logic into useTaskValidation custom hook to manage errorMessage and validationCheck functions
- Updated KanbanBoard and GanttChart to use useTaskValidation hook
- Managed projectId in store instead of using useParam
-- projectId is now passed as a parameter when calling task update mutation
-- Removed useParam from useProjectData, passed projectId as a prop instead
-- Set initial projectId in the Layout component
- Updated GanttChart to call task update API on double-click to edit task
- Modified updateTask to accept a callback prop to be called on success