### PR TITLE
[bugfix] Resolve issue with task creation when adding members

### DIFF
--- a/src/api/taskApi.ts
+++ b/src/api/taskApi.ts
@@ -7,6 +7,7 @@ import {
   DELETE_SUBTASK,
 } from "@queries/taskQueries";
 import Task from "@models/Task";
+import { TaskInput } from "@/hooks/task/useTaskMutation";
 
 /**
  * Task update api
@@ -30,7 +31,7 @@ export const updateTask = async (
  * Task create api
  */
 export const createTask = async (
-  newTask: Task
+  newTask: TaskInput
 ): Promise<{ createTask: Task }> => {
   const variables = {
     projectId: newTask.projectId,

--- a/src/hooks/task/useTaskMutation.ts
+++ b/src/hooks/task/useTaskMutation.ts
@@ -6,12 +6,25 @@ import {
   deleteTask,
   deleteSubTask,
 } from "@/api/taskApi";
-import Task from "@/models/Task";
+import Task, { Status } from "@/models/Task";
 import Project from "@/models/Project";
 
 interface UseTaskMutationProps {
   projectId: string;
   onSuccess?: () => void;
+}
+
+export interface TaskInput {
+  id?: string; // Optional, for update
+  projectId: string;
+  name: string;
+  description: string;
+  status: Status;
+  managers: string[];
+  startDate: string;
+  endDate: string;
+  progress: number;
+  priority?: boolean;
 }
 
 export const useTaskMutations = ({
@@ -78,7 +91,11 @@ export const useTaskMutations = ({
     },
   });
 
-  const createTaskMutation = useMutation<{ createTask: Task }, Error, Task>({
+  const createTaskMutation = useMutation<
+    { createTask: Task },
+    Error,
+    TaskInput
+  >({
     mutationFn: createTask,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["project"] });

--- a/src/pages/KanbanBoardPage.tsx
+++ b/src/pages/KanbanBoardPage.tsx
@@ -6,7 +6,7 @@ import Header from "@components/Header";
 import Modal from "@components/common/Modal";
 import TaskForm, { FormData } from "@/components/kanbanBoard/TaskForm";
 import { useProjectData } from "@/hooks/project/useProjectMutation";
-import { useTaskMutations } from "@/hooks/task/useTaskMutation";
+import { TaskInput, useTaskMutations } from "@/hooks/task/useTaskMutation";
 import { useTaskValidation } from "@/hooks/task/useTaskValidation";
 import { useProjectStore } from "@/store/useProjectStore";
 
@@ -40,17 +40,16 @@ const KanbanBoardPage = () => {
 
   const handleCreateTask = () => {
     if (validationCheck(formData)) {
-      const newTask: Task = {
+      const newTask: TaskInput = {
         id: "",
         projectId: project.id,
         name: formData.name,
         description: formData.description ?? "",
         status: formData.status,
-        managers: formData.managers ?? [],
+        managers: formData.managers.map((member) => member.id) ?? [],
         startDate: formData.startDate ?? "",
         endDate: formData.endDate ?? "",
         progress: 0,
-        subTasks: [],
         priority: false,
       };
 

--- a/src/queries/projectQueries.ts
+++ b/src/queries/projectQueries.ts
@@ -32,6 +32,10 @@ export const GET_PROJECT_BY_ID = gql`
         progress
         managers {
           id
+          email
+          nickname
+          isActive
+          profileImage
         }
         subTasks {
           id
@@ -43,6 +47,10 @@ export const GET_PROJECT_BY_ID = gql`
           endDate
           managers {
             id
+            email
+            nickname
+            isActive
+            profileImage
           }
         }
       }

--- a/src/queries/taskQueries.ts
+++ b/src/queries/taskQueries.ts
@@ -77,7 +77,10 @@ export const CREATE_TASK = gql`
       progress
       managers {
         id
+        email
         nickname
+        isActive
+        profileImage
       }
     }
   }


### PR DESCRIPTION
- Fixed an issue where tasks were not created when adding members during task creation
  - Created a TaskInput interface to define the request format to be sent to the server and modified the API call to use this interface
- Modified the GET_PROJECT_BY_ID query to fetch complete member information