### PR TITLE
[refactor] Refactor comment mutations for immediate subtask rendering

### DIFF
--- a/src/api/taskApi.ts
+++ b/src/api/taskApi.ts
@@ -67,7 +67,7 @@ export const deleteTask = async (
  */
 export const createSubTask = async (
   parentTaskId: string,
-  newSubTask: Omit<Task, "id" | "projectId" | "subTasks" | "managers">
+  newSubTask: Omit<TaskInput, "id" | "projectId" | "subTasks" | "managers">
 ): Promise<{ createSubTask: Task }> => {
   const variables = {
     parentTaskId,

--- a/src/components/RightToolPane.tsx
+++ b/src/components/RightToolPane.tsx
@@ -289,7 +289,6 @@ const RightToolPane = ({ isSubTask = false }: RightToolPaneProps) => {
         startDate: selectedTask.startDate,
         endDate: selectedTask.endDate,
         progress: 0,
-        comments: [],
       };
 
       createSubTask({

--- a/src/hooks/task/useTaskMutation.ts
+++ b/src/hooks/task/useTaskMutation.ts
@@ -155,7 +155,7 @@ export const useTaskMutations = ({
     Error,
     {
       parentTaskId: string;
-      subTask: Omit<Task, "id" | "projectId" | "subTasks" | "managers">;
+      subTask: Omit<TaskInput, "id" | "projectId" | "subTasks" | "managers">;
     }
   >({
     mutationFn: ({ parentTaskId, subTask }) =>


### PR DESCRIPTION
This commit refactors the comment mutations to ensure immediate rendering of comment changes in subtasks. The key changes include:

- Replacing `onSettled` with `onSuccess` for more precise UI updates after successful API calls.
- Ensuring immutability when updating comment data within subtasks, preventing potential rendering issues.
- Streamlining the update logic for both regular tasks and subtasks to maintain consistency.
- Modifying the subtask creation process to use `TaskInput` instead of `Task` for comment request data, ensuring proper data handling.